### PR TITLE
fix: 자바의 Synchronized를 사용해 동시성 이슈 해결

### DIFF
--- a/src/main/java/com/example/stock/service/StockService.java
+++ b/src/main/java/com/example/stock/service/StockService.java
@@ -14,8 +14,8 @@ public class StockService {
         this.stockRepository = stockRepository;
     }
 
-    @Transactional
-    public void decrease(Long id, Long quantity) {
+//    @Transactional
+    public synchronized void decrease(Long id, Long quantity) {
         Stock stock = stockRepository.findById(id).orElseThrow();
 
         stock.decrease(quantity);

--- a/src/test/java/com/example/stock/service/StockServiceTest.java
+++ b/src/test/java/com/example/stock/service/StockServiceTest.java
@@ -8,6 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -39,4 +43,31 @@ class StockServiceTest {
 
         assertEquals(99, stock.getQuantity());
     }
+
+    @Test
+    public void concurrency_issue() throws InterruptedException {
+        // 동시에 100개의 요청
+        int threadCount = 100;
+        // ExecutorService는 비동기로 실행하는 작업을 단순화하여 사용할 수 있게 도와주는 자바의 API
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        // 100번의 요청이 끝날 때까지 기다려야 하므로 CountDownLatch 사용
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    stockService.decrease(1L, 1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        Stock stock = stockRepository.findById(1L).orElseThrow();
+
+        // 100 - (1 * 100) = 0
+        assertEquals(0L, stock.getQuantity());
+    }
+
 }


### PR DESCRIPTION
하지만 Synchronized는 단일 프로세스에만 적용되기 때문에 다수의 서버를 운용하게 되면 동시에 여러 서버가 데이터에 접근할 수 있기 때문에  동일한 Race Condition 발생.
그래서 Synchronized는 잘 사용하지 않는다.