### PR TITLE
fix: pessimistic lock을 이용해서 정합성 맞추기

### DIFF
--- a/src/main/java/com/example/stock/repository/StockRepository.java
+++ b/src/main/java/com/example/stock/repository/StockRepository.java
@@ -2,6 +2,14 @@ package com.example.stock.repository;
 
 import com.example.stock.domain.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.persistence.LockModeType;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Stock s where s.id = :id")
+    Stock findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/com/example/stock/service/PessimisticLockStockService.java
+++ b/src/main/java/com/example/stock/service/PessimisticLockStockService.java
@@ -1,0 +1,25 @@
+package com.example.stock.service;
+
+import com.example.stock.domain.Stock;
+import com.example.stock.repository.StockRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PessimisticLockStockService {
+
+    private StockRepository stockRepository;
+
+    public PessimisticLockStockService(StockRepository stockRepository) {
+        this.stockRepository = stockRepository;
+    }
+
+    @Transactional
+    public void decrease(Long id, Long quantity) {
+        Stock stock = stockRepository.findByIdWithPessimisticLock(id);
+
+        stock.decrease(quantity);
+
+        stockRepository.saveAndFlush(stock);
+    }
+}

--- a/src/test/java/com/example/stock/service/StockServiceTest.java
+++ b/src/test/java/com/example/stock/service/StockServiceTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class StockServiceTest {
 
     @Autowired
-    private StockService stockService;
+    private PessimisticLockStockService stockService;
 
     @Autowired
     private StockRepository stockRepository;


### PR DESCRIPTION
장점
- 충돌이 빈번하게 일어난다면 Optimistic Lock보다 성능이 좋을 수 있다.
- lock을 통해 update를 제어하기 때문에 데이터 정합성이 어느정도 보장된다.

단점
- 별도의 lock을 잡기 때문에 성능 감소가 있을 수 있다.